### PR TITLE
Add Trigger.dev project

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Feel free to make a pull request to add more projects to the list.
 - [Inbox Zero](https://getinboxzero.com/github)
 - [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 
+## Remix
+
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
+
 ## Resend
 
 - [Dub.co](https://github.com/steven-tey/dub)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Feel free to make a pull request to add more projects to the list.
 - [OpenStatus](https://github.com/openstatusHQ/openstatus)
 - [Novel.sh](https://github.com/steven-tey/novel)
 - [Papermark](https://github.com/mfts/papermark)
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 - [Quivr](https://github.com/StanGirard/quivr)
 - [Vercel Platforms Starter](https://github.com/vercel/platforms)
 - [YC Idea Matcher](https://github.com/neondatabase/yc-idea-matcher)
@@ -55,6 +56,7 @@ Feel free to make a pull request to add more projects to the list.
 ## Docker
 
 - [Documenso](https://github.com/documenso/documenso)
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 
 ## Drizzle
 
@@ -103,6 +105,7 @@ Feel free to make a pull request to add more projects to the list.
 - [Dub.co](https://github.com/steven-tey/dub)
 - [Cal.com](https://github.com/calcom/cal.com)
 - [Inbox Zero](https://getinboxzero.com/github)
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 
 ## Resend
 
@@ -133,6 +136,7 @@ Feel free to make a pull request to add more projects to the list.
 - [Vercel Platforms Starter](https://github.com/vercel/platforms)
 - [YC Idea Matcher](https://github.com/neondatabase/yc-idea-matcher)
 - [OpenBio](https://github.com/vanxh/openbio)
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 
 ## Tinybird
 
@@ -156,6 +160,7 @@ Feel free to make a pull request to add more projects to the list.
 - [Cal.com](https://github.com/calcom/cal.com)
 - [Inbox Zero](https://getinboxzero.com/github)
 - [Novel.sh](https://github.com/steven-tey/novel)
+- [Trigger.dev](https://github.com/triggerdotdev/trigger.dev)
 
 ## Turso
 


### PR DESCRIPTION
🚀 This is a great idea! This PR adds the Trigger.dev project to the list of projects to learn from and adds them to the relevant sections. If you want to add a "Remix" section we could be in there as well since our API/Dashboard is implemented in Remix.