### PR TITLE
Include Glosia in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Feel free to make a pull request to add more projects to the list.
 - [NestJS](#nestjs)
 - [Next.js](#nextjs)
 - [Next Auth](#next-auth)
+- [Phoenix](#phoenix)
 - [PostHog](#posthog)
 - [Prisma](#prisma)
 - [Resend](#resend)
@@ -134,6 +135,10 @@ Feel free to make a pull request to add more projects to the list.
 - [Dub.co](https://github.com/steven-tey/dub)
 - [Inbox Zero](https://getinboxzero.com/github)
 - [Zapdos](https://github.com/pingdotgg/zapdos)
+
+## Phoenix
+
+- [Glossia](https://github.com/glossia/glossia)
 
 ## PostHog
 


### PR DESCRIPTION
I'm working on an AI-powered open source tool using the Elixir framework [Phoenix](https://www.phoenixframework.org/), [Glossia](https://github.com/glossia/glossia). This PR includes the project in the README.